### PR TITLE
[WIP] Slack上でスタート・ストップできるようにする

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -13,12 +13,15 @@ gutil = require 'gulp-util'
 rename = require 'gulp-rename'
 jeditor = require 'gulp-json-editor'
 fs = require 'fs'
+gulpif = require 'gulp-if'
+sourcemaps = require 'gulp-sourcemaps'
 
 gulp.task 'default', ['watch']
 
 isProduction = gutil.env.production?
 isStaging = gutil.env.staging?
 isDeploy = isProduction || isStaging
+isDevelopment = !isDeploy
 envName = 'development'
 envName = 'production' if isProduction
 envName = 'staging' if isStaging
@@ -30,8 +33,13 @@ gulp.task 'zip', ['coffeelint', 'coffee', 'scsslint', 'scss', 'manifest', 'img']
 
 gulp.task 'coffee', ['env'], ->
   gulp.src './src/coffee/*.coffee'
+    .pipe gulpif(isDevelopment, sourcemaps.init())
     .pipe plumber()
     .pipe coffee()
+    .pipe gulpif(isDevelopment, sourcemaps.write '.',
+      addComment: true
+      sourceRoot: '/src'
+    )
     .pipe if isDeploy then uglify(preserveComments: 'some') else gutil.noop()
     .pipe gulp.dest('./app/js')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "coffee-script": "^1.9.1",
+    "del": "*",
     "gulp": "*",
     "gulp-coffee": "*",
     "gulp-sass": "*",
@@ -8,13 +9,13 @@
     "gulp-cssnano": "*",
     "gulp-scss-lint": "*",
     "gulp-coffeelint": "*",
-    "gulp-plumber": "*",
-    "gulp-uglify": "*",
-    "gulp-zip": "*",
-    "gulp-zip": "*",
-    "gulp-util": "*",
-    "gulp-rename": "*",
+    "gulp-if": "^2.0.1",
     "gulp-json-editor": "*",
-    "del": "*"
+    "gulp-plumber": "*",
+    "gulp-rename": "*",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-uglify": "*",
+    "gulp-util": "*",
+    "gulp-zip": "*"
   }
 }

--- a/src/coffee/annotator.coffee
+++ b/src/coffee/annotator.coffee
@@ -20,7 +20,7 @@ class Annotator
     observer.observe(document, options)
     @_annotate(selector, modifier)
 
-  # FIXME: 消すか名前を変えたい(countIconなど？)
+  # FIXME: 名前を変えたい(logoIcon とか)
   stopIcon: (element) ->
     @_icon(element, 'stop', @iconOnly)
 
@@ -122,6 +122,7 @@ class Annotator
   _get: (element, value) ->
     element.querySelector("[itemprop=\"#{value}\"]").textContent
 
+  # FIXME: アイコンフォントにしたい
   _startIcon: (size, color = '#999') ->
     d = 'M16,1A15,15,0,1,1,1,16,15,15,0,0,1,16,' +
       '1m0-1A16,16,0,1,0,32,16,16,16,0,0,0,16,0h0Z'

--- a/src/coffee/annotator.coffee
+++ b/src/coffee/annotator.coffee
@@ -8,6 +8,9 @@ options =
 itemtype = 'http://schema.org/Action/StartAction'
 
 class Annotator
+  constructor: ->
+    @_iconOnly = false
+
   observe: (selector, modifier) ->
     observer = new MutationObserver (mutations) =>
       observer.disconnect()
@@ -18,16 +21,24 @@ class Annotator
     @_annotate(selector, modifier)
 
   startLabel: (element) ->
+    @_iconOnly = false
     @_icon(element, 'start')
 
   stopLabel: (element) ->
-    @_icon(element, 'stop')
+    @_icon(element, 'stop', @_iconOnly)
 
   startIcon: (element) ->
-    @_icon(element, 'start', true)
+    @_iconOnly = true
+    @_icon(element, 'start', @_iconOnly)
 
   stopIcon: (element) ->
-    @_icon(element, 'stop', true)
+    @_icon(element, 'stop', @_iconOnly)
+
+  start: (element) ->
+    @_icon(element, 'start', @_iconOnly)
+
+  stop: (element) ->
+    @_icon(element, 'stop', @_iconOnly)
 
   _icon: (element, type, iconOnly = false) ->
     style = getComputedStyle(element, null)

--- a/src/coffee/annotator.coffee
+++ b/src/coffee/annotator.coffee
@@ -20,17 +20,6 @@ class Annotator
     observer.observe(document, options)
     @_annotate(selector, modifier)
 
-  startLabel: (element) ->
-    @iconOnly = false
-    @_icon(element, 'start')
-
-  stopLabel: (element) ->
-    @_icon(element, 'stop', @iconOnly)
-
-  startIcon: (element) ->
-    @iconOnly = true
-    @_icon(element, 'start', @iconOnly)
-
   stopIcon: (element) ->
     @_icon(element, 'stop', @iconOnly)
 

--- a/src/coffee/annotator.coffee
+++ b/src/coffee/annotator.coffee
@@ -30,14 +30,16 @@ class Annotator
   stop: (element) ->
     @_icon(element, 'stop', @iconOnly)
 
+  getMessage: (type) ->
+    chrome.i18n.getMessage("content_#{type}") ? type
+
   _icon: (element, type, iconOnly = false) ->
     style = getComputedStyle(element, null)
     size = Math.round(parseInt(style.fontSize) * 1.2)
     color = style.color
 
     icon = @["_#{type}Icon"](size, color)
-    message = chrome.i18n.getMessage("content_#{type}") ? type
-    if iconOnly then icon else "#{icon} #{message}"
+    if iconOnly then icon else "#{icon} #{@getMessage(type)}"
 
   _annotate: (selector, modifier) ->
     for element in Array::slice.call(document.querySelectorAll(selector))

--- a/src/coffee/annotator.coffee
+++ b/src/coffee/annotator.coffee
@@ -20,6 +20,7 @@ class Annotator
     observer.observe(document, options)
     @_annotate(selector, modifier)
 
+  # FIXME: 消すか名前を変えたい(countIconなど？)
   stopIcon: (element) ->
     @_icon(element, 'stop', @iconOnly)
 

--- a/src/coffee/annotator.coffee
+++ b/src/coffee/annotator.coffee
@@ -9,7 +9,7 @@ itemtype = 'http://schema.org/Action/StartAction'
 
 class Annotator
   constructor: ->
-    @_iconOnly = false
+    @iconOnly = false
 
   observe: (selector, modifier) ->
     observer = new MutationObserver (mutations) =>
@@ -21,24 +21,24 @@ class Annotator
     @_annotate(selector, modifier)
 
   startLabel: (element) ->
-    @_iconOnly = false
+    @iconOnly = false
     @_icon(element, 'start')
 
   stopLabel: (element) ->
-    @_icon(element, 'stop', @_iconOnly)
+    @_icon(element, 'stop', @iconOnly)
 
   startIcon: (element) ->
-    @_iconOnly = true
-    @_icon(element, 'start', @_iconOnly)
+    @iconOnly = true
+    @_icon(element, 'start', @iconOnly)
 
   stopIcon: (element) ->
-    @_icon(element, 'stop', @_iconOnly)
+    @_icon(element, 'stop', @iconOnly)
 
   start: (element) ->
-    @_icon(element, 'start', @_iconOnly)
+    @_icon(element, 'start', @iconOnly)
 
   stop: (element) ->
-    @_icon(element, 'stop', @_iconOnly)
+    @_icon(element, 'stop', @iconOnly)
 
   _icon: (element, type, iconOnly = false) ->
     style = getComputedStyle(element, null)

--- a/src/coffee/annotator.coffee
+++ b/src/coffee/annotator.coffee
@@ -23,6 +23,9 @@ class Annotator
   stopLabel: (element) ->
     @_icon(element, 'stop')
 
+  startIcon: (element) ->
+    @_icon(element, 'start', true)
+
   stopIcon: (element) ->
     @_icon(element, 'stop', true)
 

--- a/src/coffee/annotator.coffee
+++ b/src/coffee/annotator.coffee
@@ -54,9 +54,12 @@ class Annotator
     @_set(element, 'itemtype', itemtype)
 
   getItem: (element) ->
+    @getParent(element, 'itemtype', itemtype)
+
+  getParent: (element, attr, itemprop) ->
     item = element
     i = 0
-    while item.getAttribute('itemtype') != itemtype && i < 20
+    while item.getAttribute(attr) != itemprop && i < 20
       item = item.parentNode
       i += 1
     item

--- a/src/coffee/chatwork.coffee
+++ b/src/coffee/chatwork.coffee
@@ -60,6 +60,7 @@ annotator.observe '._message', (element) ->
     li = document.createElement('li')
     li.className = 'linkStatus'
 
+    # FIXME: annotatorの中に閉じたい
     label = document.createElement('span')
     label.className = 'showAreatext'
     annotator.setLabel(label)

--- a/src/coffee/chatwork.coffee
+++ b/src/coffee/chatwork.coffee
@@ -66,7 +66,7 @@ annotator.observe '._message', (element) ->
     li.appendChild(label)
 
     nav.insertBefore(li, action.nextSibling)
-    label.innerHTML = annotator.startLabel(label)
+    label.innerHTML = annotator.start(label)
 
   unless annotator.hasCount(element)
     #icon = annotator.stopIcon(14)

--- a/src/coffee/content.coffee
+++ b/src/coffee/content.coffee
@@ -339,7 +339,8 @@ try
       TimeCrowd.content.start(name, url, parentName, parentURL)
 
       loading = chrome.i18n.getMessage('content_loading')
-      target.innerHTML = target.innerHTML.replace(/<\/svg>[\s\S]*$/, "</svg> #{loading}")
+      html = target.innerHTML.replace(/<\/svg>[\s\S]*$/, "</svg> #{loading}")
+      target.innerHTML = html
 
   chrome.runtime.onMessage.addListener (message, sender, sendResponse) ->
     if message.action == 'title'

--- a/src/coffee/content.coffee
+++ b/src/coffee/content.coffee
@@ -318,7 +318,7 @@ try
   document.addEventListener('page:fetch', initForTurbolinks)
 
   document.addEventListener 'click', (e) ->
-    target = e.target
+    target = e.target.getAttribute('itemprop') || jQuery(e.target).parents("span[itemprop='label']")[0]
     return unless target.getAttribute('itemprop') == 'label'
 
     id = target.dataset.timeCrowdTimeEntryId

--- a/src/coffee/content.coffee
+++ b/src/coffee/content.coffee
@@ -83,7 +83,7 @@ try
 
     _startLabel: (element, json, duration) ->
       if !element.dataset.timeCrowdTimeEntryId
-        element.innerHTML = TimeCrowd.annotator.stopLabel(element)
+        element.innerHTML = TimeCrowd.annotator.stop(element)
         element.dataset.timeCrowdTimeEntryId = json.id
         duration.dataset.duration = json.duration
 
@@ -97,7 +97,7 @@ try
 
     _stopLabel: (element, duration) ->
       if element.dataset.timeCrowdTimeEntryId
-        element.innerHTML = TimeCrowd.annotator.startLabel(element)
+        element.innerHTML = TimeCrowd.annotator.start(element)
         delete element.dataset.timeCrowdTimeEntryId
         delete duration.dataset.duration
         delete duration.dataset.startedAt

--- a/src/coffee/content.coffee
+++ b/src/coffee/content.coffee
@@ -318,11 +318,14 @@ try
   document.addEventListener('page:fetch', initForTurbolinks)
 
   document.addEventListener 'click', (e) ->
-    target = if e.target.getAttribute('itemprop') then e.target else jQuery(e.target).parents("span[itemprop='label']")[0]
-    return unless target.getAttribute('itemprop') == 'label'
+    annotator = TimeCrowd.annotator
+
+    target = if e.target.getAttribute('itemprop')
+      e.target
+    else
+      annotator.getParent(e.target, 'itemprop', 'label')
 
     id = target.dataset.timeCrowdTimeEntryId
-    annotator = TimeCrowd.annotator
     item = annotator.getItem(target)
     return unless item
 

--- a/src/coffee/content.coffee
+++ b/src/coffee/content.coffee
@@ -318,7 +318,7 @@ try
   document.addEventListener('page:fetch', initForTurbolinks)
 
   document.addEventListener 'click', (e) ->
-    target = e.target.getAttribute('itemprop') || jQuery(e.target).parents("span[itemprop='label']")[0]
+    target = if e.target.getAttribute('itemprop') then e.target else jQuery(e.target).parents("span[itemprop='label']")[0]
     return unless target.getAttribute('itemprop') == 'label'
 
     id = target.dataset.timeCrowdTimeEntryId

--- a/src/coffee/duration.coffee
+++ b/src/coffee/duration.coffee
@@ -19,7 +19,7 @@ class Duration
 
     if element.getAttribute('itemprop') == 'count'
       html = @_format(duration)
-      if element.dataset.withIcon == 'false'
+      if element.dataset.withIcon == 'true'
         html = "#{TimeCrowd.annotator.stopIcon(element)} #{html}"
       element.innerHTML = html
     else

--- a/src/coffee/duration.coffee
+++ b/src/coffee/duration.coffee
@@ -19,7 +19,7 @@ class Duration
 
     if element.getAttribute('itemprop') == 'count'
       html = @_format(duration)
-      if element.dataset.withIcon
+      if element.dataset.withIcon == 'false'
         html = "#{TimeCrowd.annotator.stopIcon(element)} #{html}"
       element.innerHTML = html
     else

--- a/src/coffee/slack.coffee
+++ b/src/coffee/slack.coffee
@@ -55,15 +55,20 @@ annotator.observe 'ts-message', (element) ->
 
   unless annotator.hasLabel(element)
     a = document.createElement('a')
-    a.className = 'linkStatus'
+    a.className = 'linkStatus ts_icon ts_tip ts_tip_top ts_tip_float ts_tip_delay_60 ts_tip_hidden'
 
     label = document.createElement('span')
     # label.className = 'showAreatext'
     annotator.setLabel(label)
     a.appendChild(label)
 
+    tooltip = document.createElement('span')
+    tooltip.className = 'ts_tip_tip'
+    tooltip.textContent = 'Start'
+    a.appendChild(tooltip)
+
     nav.insertBefore(a, action)
-    label.innerHTML = annotator.startLabel(label)
+    label.innerHTML = annotator.startIcon(label)
 
   unless annotator.hasCount(element)
     #icon = annotator.stopIcon(14)

--- a/src/coffee/slack.coffee
+++ b/src/coffee/slack.coffee
@@ -66,7 +66,7 @@ annotator.observe 'ts-message', (element) ->
 
     tooltip = document.createElement('span')
     tooltip.className = 'ts_tip_tip'
-    tooltip.textContent = 'Start'
+    tooltip.textContent = annotator.getMessage('start')
     a.appendChild(tooltip)
 
     nav.insertBefore(a, action)

--- a/src/coffee/slack.coffee
+++ b/src/coffee/slack.coffee
@@ -56,7 +56,8 @@ annotator.observe 'ts-message', (element) ->
 
   unless annotator.hasLabel(element)
     a = document.createElement('a')
-    a.className = 'linkStatus ts_icon ts_tip ts_tip_top ts_tip_float ts_tip_delay_60 ts_tip_hidden'
+    tip = 'ts_tip ts_tip_top ts_tip_float ts_tip_delay_60 ts_tip_hidden'
+    a.className = "ts_icon #{tip}"
 
     label = document.createElement('span')
     # label.className = 'showAreatext'

--- a/src/coffee/slack.coffee
+++ b/src/coffee/slack.coffee
@@ -13,7 +13,7 @@ annotator.observe 'ts-message', (element) ->
   content = element.querySelector('.message_body')
   return unless content
 
-  starholder = element.querySelector('.message_star_holder')
+  starholder = element.querySelector('.message_content > .message_star_holder')
   return unless starholder
 
   # rid = element.dataset.rid
@@ -71,6 +71,7 @@ annotator.observe 'ts-message', (element) ->
     # br = document.createElement('br')
     #timestamp.appendChild(br)
     #timestamp.appendChild(icon)
+    console.log starholder.parentNode
     starholder.parentNode.insertBefore(count, starholder)
-    # count.classList.add('timestamp')
+    count.classList.add('timestamp')
 

--- a/src/coffee/slack.coffee
+++ b/src/coffee/slack.coffee
@@ -13,8 +13,8 @@ annotator.observe 'ts-message', (element) ->
   content = element.querySelector('.message_body')
   return unless content
 
-  # timestamp = element.querySelector('._timeStamp')
-  # return unless timestamp
+  starholder = element.querySelector('.message_star_holder')
+  return unless starholder
 
   # rid = element.dataset.rid
 
@@ -65,12 +65,12 @@ annotator.observe 'ts-message', (element) ->
     nav.insertBefore(a, action)
     label.innerHTML = annotator.startLabel(label)
 
-  # unless annotator.hasCount(element)
-  #   #icon = annotator.stopIcon(14)
-  #   count = annotator.countNode()
-  #   br = document.createElement('br')
-  #   timestamp.appendChild(br)
-  #   #timestamp.appendChild(icon)
-  #   timestamp.appendChild(count)
-  #   timestamp.style.textAlign = 'right'
+  unless annotator.hasCount(element)
+    #icon = annotator.stopIcon(14)
+    count = annotator.countNode()
+    # br = document.createElement('br')
+    #timestamp.appendChild(br)
+    #timestamp.appendChild(icon)
+    starholder.parentNode.insertBefore(count, starholder)
+    # count.classList.add('timestamp')
 

--- a/src/coffee/slack.coffee
+++ b/src/coffee/slack.coffee
@@ -41,7 +41,7 @@ annotator.observe 'ts-message', (element) ->
     annotator.setURL(url)
 
   unless annotator.hasParentName(element)
-    text = 'test'# document.querySelector('._roomTitleText').textContent
+    text = document.querySelector('#channel_title').textContent
     name = annotator.hiddenDiv text
     element.appendChild(name)
     annotator.setParentName(name)
@@ -49,7 +49,7 @@ annotator.observe 'ts-message', (element) ->
   unless annotator.hasParentURL(element)
     #mid = element.dataset.mid
 
-    url = annotator.hiddenDiv "https://www.chatwork.com/"#!rid#{rid}"
+    url = annotator.hiddenDiv window.location.href
     element.appendChild(url)
     annotator.setParentURL(url)
 

--- a/src/coffee/slack.coffee
+++ b/src/coffee/slack.coffee
@@ -1,0 +1,76 @@
+'use strict'
+
+annotator = TimeCrowd.annotator
+
+annotator.observe 'ts-message', (element) ->
+  nav = element.querySelector '.action_hover_container'
+  return unless nav
+
+  actions = nav.querySelectorAll 'a'
+  action = actions[actions.length - 1]
+  return unless action
+
+  content = element.querySelector('.message_body')
+  return unless content
+
+  # timestamp = element.querySelector('._timeStamp')
+  # return unless timestamp
+
+  # rid = element.dataset.rid
+
+  annotator.setItem(element)
+
+  unless annotator.hasName(element)
+    clone = content.cloneNode(true)
+    # replaces = clone.querySelectorAll('.searchEm')
+    # for elm in Array::slice.call(replaces)
+    #   elm.outerHTML = elm.textContent
+    # noises = clone.querySelectorAll('span, time, ._messageLink')
+    # for elm in Array::slice.call(noises)
+    #   elm.parentNode.removeChild(elm)
+    # for elm in Array::slice.call(clone.querySelectorAll('a'))
+    #   if /^https:\/\/www.chatwork.com\/#!rid\d+/.test(elm.href)
+    #     elm.parentNode.removeChild(elm)
+    name = annotator.hiddenDiv clone.textContent
+    element.appendChild(name)
+    annotator.setName(name)
+
+  unless annotator.hasURL(element)
+    url = annotator.hiddenDiv nav.dataset.abs_permalink
+    element.appendChild(url)
+    annotator.setURL(url)
+
+  unless annotator.hasParentName(element)
+    text = 'test'# document.querySelector('._roomTitleText').textContent
+    name = annotator.hiddenDiv text
+    element.appendChild(name)
+    annotator.setParentName(name)
+
+  unless annotator.hasParentURL(element)
+    #mid = element.dataset.mid
+
+    url = annotator.hiddenDiv "https://www.chatwork.com/"#!rid#{rid}"
+    element.appendChild(url)
+    annotator.setParentURL(url)
+
+  unless annotator.hasLabel(element)
+    a = document.createElement('a')
+    a.className = 'linkStatus'
+
+    label = document.createElement('span')
+    # label.className = 'showAreatext'
+    annotator.setLabel(label)
+    a.appendChild(label)
+
+    nav.insertBefore(a, action)
+    label.innerHTML = annotator.startLabel(label)
+
+  # unless annotator.hasCount(element)
+  #   #icon = annotator.stopIcon(14)
+  #   count = annotator.countNode()
+  #   br = document.createElement('br')
+  #   timestamp.appendChild(br)
+  #   #timestamp.appendChild(icon)
+  #   timestamp.appendChild(count)
+  #   timestamp.style.textAlign = 'right'
+

--- a/src/coffee/slack.coffee
+++ b/src/coffee/slack.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
 annotator = TimeCrowd.annotator
+annotator.iconOnly = true
 
 annotator.observe 'ts-message', (element) ->
   nav = element.querySelector '.action_hover_container'
@@ -68,7 +69,7 @@ annotator.observe 'ts-message', (element) ->
     a.appendChild(tooltip)
 
     nav.insertBefore(a, action)
-    label.innerHTML = annotator.startIcon(label)
+    label.innerHTML = annotator.start(label)
 
   unless annotator.hasCount(element)
     #icon = annotator.stopIcon(14)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,7 +31,7 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],
-      "js": ["js/namespace.js", "js/keys.js", "js/env.js", "js/api.js", "js/duration.js", "js/annotator.js", "js/content.js"],
+      "js": ["vendor/jquery.min.js", "js/namespace.js", "js/keys.js", "js/env.js", "js/api.js", "js/duration.js", "js/annotator.js", "js/content.js"],
       "css": ["css/content.css"]
     },
     {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -38,6 +38,11 @@
       "matches": ["https://www.chatwork.com/*"],
       "js": ["js/chatwork.js"],
       "css": ["css/chatwork.css"]
+    },
+    {
+      "matches": ["https://*.slack.com/*"],
+      "js": ["js/slack.js"],
+      "css": ["css/slack.css"]
     }
   ],
   "background": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,7 +31,7 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],
-      "js": ["vendor/jquery.min.js", "js/namespace.js", "js/keys.js", "js/env.js", "js/api.js", "js/duration.js", "js/annotator.js", "js/content.js"],
+      "js": ["js/namespace.js", "js/keys.js", "js/env.js", "js/api.js", "js/duration.js", "js/annotator.js", "js/content.js"],
       "css": ["css/content.css"]
     },
     {


### PR DESCRIPTION
## チャットワーク連携概要

https://note.ruffnote.com/p/23849
## 実装
- [x] slackのHTML構造把握
  - [x] itemscope (wrapper)
  - [x] name
  - [x] url
  - [x] parentName
  - [x] parentURL
  - [x] label (start button)
  - [x] count (duration)
- [x] slack.coffeeを追加
- [x] manifest.jsonを更新
- [x] 見た目をSlackにマッチさせる
  - [x] startをアイコン表示のみにする
  - [x] stopをアイコン表示のみにする
- [x] スタートした時に、タイマーの横にアイコンがちらつく
- [ ] スタートすると、他のメッセージにあるスタートボタンアイコンが表示されなくなる
- [ ] 停止ボタンのtooltipもstartになってる
- [ ] 同一人物の発言の2行目以降にカウントアップが表示されない
- [x] jQueryやめる
- [x] tooltipの日本語化
